### PR TITLE
add support for Firefox & manifest v2

### DIFF
--- a/sponsorblock-odysee/manifest.json
+++ b/sponsorblock-odysee/manifest.json
@@ -2,15 +2,15 @@
 	"name": "SponsorBlock for Odysee",
 	"version": "1.2.1",
 	"description": "Skip sponsored segments on Odysee videos imported from YouTube. Very basic plugin - only load and skip sponsored segments.",
-	"manifest_version": 3,
+	"manifest_version": 2,
 	"options_ui": {
 		"page": "options.html",
 		"open_in_tab": false
 	},
-	"action": {
-		"name": "SponsorBlock for Odysee",
+	"browser_action": {
+		"default_title": "SponsorBlock for Odysee",
 		"default_popup": "options.html",
-		"icons": { "16": "icon16.png",
+		"default_icon": { "16": "icon16.png",
 			   "32": "icon32.png",
 			   "48": "icon48.png",
 			   "128": "icon128.png" }
@@ -19,22 +19,29 @@
 		{
 			"js": ["odyseesponsorskip.js"],
 			"css": ["styles.css"],
-			"matches": ["https://*.odysee.com/*"],
+			"matches": ["https://*.odysee.com/*", "https://odysee.com/*"],
 			"run_at": "document_start",
 			"all_frames": true
 		}
 	],
 	
 	"permissions": [
-		"storage"
-	],
-	"host_permissions": [
-		  "https://*.odysee.com/*"
+		"https://sponsor.ajay.app/*",
+		"https://*.odysee.com/*",
+		"https://odysee.com/*",
+		"storage",
+		"scripting"
 	],
 	"icons": {
 	   "16": "icon16.png",
 	   "32": "icon32.png",
 	   "48": "icon48.png",
 	   "128": "icon128.png"
+	},
+	"browser_specific_settings": {
+		"gecko": {
+			"id": "sponsorBlockerForOdysee@ajay.app",
+			"strict_min_version": "48.0"
+		}
 	}
 }

--- a/sponsorblock-odysee/odyseesponsorskip.js
+++ b/sponsorblock-odysee/odyseesponsorskip.js
@@ -14,18 +14,116 @@ chrome.storage.sync.get({
 	}
 });
 
+function sha256(ascii) {
+    function rightRotate(value, amount) {
+        return (value>>>amount) | (value<<(32 - amount));
+    };
+
+    var mathPow = Math.pow;
+    var maxWord = mathPow(2, 32);
+    var lengthProperty = 'length'
+    var i, j; // Used as a counter across the whole file
+    var result = ''
+
+    var words = [];
+    var asciiBitLength = ascii[lengthProperty]*8;
+
+    //* caching results is optional - remove/add slash from front of this line to toggle
+    // Initial hash value: first 32 bits of the fractional parts of the square roots of the first 8 primes
+    // (we actually calculate the first 64, but extra values are just ignored)
+    var hash = sha256.h = sha256.h || [];
+    // Round constants: first 32 bits of the fractional parts of the cube roots of the first 64 primes
+    var k = sha256.k = sha256.k || [];
+    var primeCounter = k[lengthProperty];
+    /*/
+    var hash = [], k = [];
+    var primeCounter = 0;
+    //*/
+
+    var isComposite = {};
+    for (var candidate = 2; primeCounter < 64; candidate++) {
+        if (!isComposite[candidate]) {
+            for (i = 0; i < 313; i += candidate) {
+                isComposite[i] = candidate;
+            }
+            hash[primeCounter] = (mathPow(candidate, .5)*maxWord)|0;
+            k[primeCounter++] = (mathPow(candidate, 1/3)*maxWord)|0;
+        }
+    }
+
+    ascii += '\x80' // Append Ƈ' bit (plus zero padding)
+    while (ascii[lengthProperty]%64 - 56) ascii += '\x00' // More zero padding
+    for (i = 0; i < ascii[lengthProperty]; i++) {
+        j = ascii.charCodeAt(i);
+        if (j>>8) return; // ASCII check: only accept characters in range 0-255
+        words[i>>2] |= j << ((3 - i)%4)*8;
+    }
+    words[words[lengthProperty]] = ((asciiBitLength/maxWord)|0);
+    words[words[lengthProperty]] = (asciiBitLength)
+
+    // process each chunk
+    for (j = 0; j < words[lengthProperty];) {
+        var w = words.slice(j, j += 16); // The message is expanded into 64 words as part of the iteration
+        var oldHash = hash;
+        // This is now the undefinedworking hash", often labelled as variables a...g
+        // (we have to truncate as well, otherwise extra entries at the end accumulate
+        hash = hash.slice(0, 8);
+
+        for (i = 0; i < 64; i++) {
+            var i2 = i + j;
+            // Expand the message into 64 words
+            // Used below if
+            var w15 = w[i - 15], w2 = w[i - 2];
+
+            // Iterate
+            var a = hash[0], e = hash[4];
+            var temp1 = hash[7]
+                + (rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25)) // S1
+                + ((e&hash[5])^((~e)&hash[6])) // ch
+                + k[i]
+                // Expand the message schedule if needed
+                + (w[i] = (i < 16) ? w[i] : (
+                        w[i - 16]
+                        + (rightRotate(w15, 7) ^ rightRotate(w15, 18) ^ (w15>>>3)) // s0
+                        + w[i - 7]
+                        + (rightRotate(w2, 17) ^ rightRotate(w2, 19) ^ (w2>>>10)) // s1
+                    )|0
+                );
+            // This is only used once, so *could* be moved below, but it only saves 4 bytes and makes things unreadble
+            var temp2 = (rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22)) // S0
+                + ((a&hash[1])^(a&hash[2])^(hash[1]&hash[2])); // maj
+
+            hash = [(temp1 + temp2)|0].concat(hash); // We don't bother trimming off the extra ones, they're harmless as long as we're truncating when we do the slice()
+            hash[4] = (hash[4] + temp1)|0;
+        }
+
+        for (i = 0; i < 8; i++) {
+            hash[i] = (hash[i] + oldHash[i])|0;
+        }
+    }
+
+    for (i = 0; i < 8; i++) {
+        for (j = 3; j + 1; j--) {
+            var b = (hash[i]>>(j*8))&255;
+            result += ((b < 16) ? 0 : '') + b.toString(16);
+        }
+    }
+    return result;
+}
+
 function init(options) {
 	var isNotifications = options[0];
 	var selectedCategories = options[1];
 	var notif_time = options[2];
 	var categories = "";
 	if (selectedCategories && selectedCategories != "[]" && selectedCategories != "") {
-		categories = "&categories=" + selectedCategories;
+		categories = "categories=" + selectedCategories;
 	}
 
 	function fetch_segments(video_id) {
+		const hash = sha256(video_id).slice(0, 4);
 		return new Promise((resolve, reject) => {
-			fetch("https://sponsor.ajay.app/api/skipSegments?videoID=" + video_id + categories)
+			fetch("https://sponsor.ajay.app/api/skipSegments/" + hash + "?" + categories)
 			.then((response) => {
 				if (response.ok) {
 					return response.json();
@@ -171,12 +269,22 @@ function init(options) {
 
 		var segments = null;
 
-		fetch_segments(id).then(function (segments_) {
+		fetch_segments(id).then(function (videos) {
 
-			if (!segments_ || segments_ == "api_error" || !Array.isArray(segments_) || segments_.length < 1) {
+			if (!videos || videos == "api_error" || !Array.isArray(videos) || videos.length < 1) {
 				return;
 			}
-			segments = segments_;
+
+			videos.forEach(seg => {
+				if(seg.videoID === id) {
+					segments = seg.segments;
+				}
+			});
+
+			if(!segments) {
+				return;
+			}
+
 			document.getElementById('vjs_video_3').className += ' sponsorTrue';
 			//console.log(segments);
 			if (isNotifications) {


### PR DESCRIPTION
This branch adds support for Firefox & manifest v2. It also uses the current version of the API which requires a hash of the videoID and looping through the results to get the matching video segments. Change as you see fit.